### PR TITLE
Add ESP32-C3 super mini support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,15 @@ upload_speed = 921600
 lib_deps = electroniccats/MPU6050@^1.4.4
             ArduinoOTA
 
+[env:esp32-c3-supermini]
+platform = espressif32
+board = esp32-c3-devkitm-1
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps = electroniccats/MPU6050@^1.4.4
+            ArduinoOTA
+
 [env:dronegazeOTA]
 platform = espressif32
 upload_port = 192.168.4.1


### PR DESCRIPTION
## Summary
- Add define-driven board configuration supporting ESP32-C3 Super Mini with custom pin map, task sizes, and buzzer
- Introduce CREATE_TASK macro to adapt FreeRTOS task creation for single-core vs dual-core targets
- Add PlatformIO environment for ESP32-C3 Super Mini

## Testing
- `pio run -e nodemcu-32s`
- `pio run -e esp32-c3-supermini`


------
https://chatgpt.com/codex/tasks/task_e_68aeeafdcef8832aa9fac91cc0ceb247