### PR TITLE
Generalize ESC PWM for ESP32-C3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,15 @@ upload_speed = 921600
 lib_deps = electroniccats/MPU6050@^1.4.4
             ArduinoOTA
 
+[env:esp32-c3-supermini]
+platform = espressif32
+board = esp32-c3-devkitm-1
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps = electroniccats/MPU6050@^1.4.4
+            ArduinoOTA
+
 [env:dronegazeOTA]
 platform = espressif32
 upload_port = 192.168.4.1
@@ -26,3 +35,4 @@ monitor_speed = 115200
 upload_speed = 921600
 lib_deps = electroniccats/MPU6050@^1.4.4
             ArduinoOTA
+

--- a/src/ESC.cpp
+++ b/src/ESC.cpp
@@ -14,6 +14,7 @@ void ESC::arm(int pulse) {
 
 void ESC::writeMicroseconds(int pulse) {
     pulse = constrain(pulse, 1000, 2000);
-    uint32_t duty = map(pulse, 1000, 2000, 3276, 6553); // 16-bit PWM
+    uint32_t maxDuty = (1 << _resolution) - 1;
+    uint32_t duty = (uint64_t)maxDuty * pulse * _freq / 1000000; // scale to period
     ledcWrite(_channel, duty);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,11 +11,42 @@
 #include <EEPROM.h>
 #include "QuadFilter.h"
 
+// ==================== BOARD CONFIGURATION ====================
+// Select pin mappings and task sizes based on target board
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+// ESP32-C3 Super Mini (RISC-V single core)
+const int PIN_MFL = 20; // MTL
+const int PIN_MFR = 10; // MTR
+const int PIN_MBL = 21; // MBL
+const int PIN_MBR = 9;  // MBR
+const int BUZZER_PIN = 6;
+const uint32_t CPU_FREQ_MHZ = 160;
+const int PWM_RESOLUTION = 14;
+// Reduced stack sizes for smaller RAM
+const uint16_t FAST_TASK_STACK = 2048;
+const uint16_t COMM_TASK_STACK = 4096;
+const uint16_t FAILSAFE_TASK_STACK = 2048;
+const uint16_t OTA_TASK_STACK = 2048;
+#define CREATE_TASK(fn, name, stack, prio, handle, core) xTaskCreate(fn, name, stack, NULL, prio, handle)
+#else
+// Default ESP32 (e.g., NodeMCU-32S)
+const int PIN_MFL = 14;
+const int PIN_MFR = 27;
+const int PIN_MBL = 26;
+const int PIN_MBR = 25;
+const int BUZZER_PIN = -1; // No buzzer by default
+const uint32_t CPU_FREQ_MHZ = 240;
+const int PWM_RESOLUTION = 16;
+const uint16_t FAST_TASK_STACK = 4096;
+const uint16_t COMM_TASK_STACK = 8192;
+const uint16_t FAILSAFE_TASK_STACK = 2048;
+const uint16_t OTA_TASK_STACK = 2048;
+#define CREATE_TASK(fn, name, stack, prio, handle, core) xTaskCreatePinnedToCore(fn, name, stack, NULL, prio, handle, core)
+#endif
+
 /// ==================== CONSTANTS ====================
 const char *WIFI_SSID = "Dronegaze Telemetry port";
 const char *WIFI_PASSWORD = "ASCEpec@2025";
-IPAddress ip = {192,168,4,1};
-
 const int TCP_PORT = 8000;
 const int EEPROM_SIZE = 512*6;
 const int EEPROM_ADDR = 0x0;
@@ -123,7 +154,10 @@ struct MotorOutputs
 // ==================== GLOBAL VARIABLES ====================
 // Hardware
 MPU6050 mpu;
-ESC escFL(14, 0), escFR(27, 1), escBL(26, 2), escBR(25, 3);
+ESC escFL(PIN_MFL, 0, 50, PWM_RESOLUTION),
+    escFR(PIN_MFR, 1, 50, PWM_RESOLUTION),
+    escBL(PIN_MBL, 2, 50, PWM_RESOLUTION),
+    escBR(PIN_MBR, 3, 50, PWM_RESOLUTION);
 WiFiServer server(TCP_PORT);
 WiFiClient client;
 KalmanFilter kalmanX, kalmanY, kalmanZ;
@@ -890,16 +924,32 @@ void OTATask(void *pvParameters) {
     }
 }
 
+void setupWiFi() {
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(WIFI_SSID, WIFI_PASSWORD);
+    Serial.print("Access Point started, IP: ");
+    Serial.println(WiFi.softAPIP());
+    ArduinoOTA.begin();
+    server.begin();
+}
+
 void setup()
 {
     Serial.begin(115200);
     Serial.println("Flight Controller Starting...");
 
+    if (BUZZER_PIN >= 0) {
+        pinMode(BUZZER_PIN, OUTPUT);
+        digitalWrite(BUZZER_PIN, HIGH);
+        delay(100);
+        digitalWrite(BUZZER_PIN, LOW);
+    }
+
     // Initialize EEPROM
     EEPROM.begin(EEPROM_SIZE);
     loadPIDFromEEPROM();
     Serial.println(3 * sizeof(PIDController) + 3 * sizeof(CascadedFilter));
-    setCpuFrequencyMhz(240);
+    setCpuFrequencyMhz(CPU_FREQ_MHZ);
     // Initialize ESCs
     escFL.attach();
     escFR.attach();
@@ -921,13 +971,7 @@ void setup()
     // escBR.writeMicroseconds(1000);
     // delay(2000);
 
-    // Initialize WiFi
-    WiFi.mode(WIFI_AP_STA);
-    WiFi.config(ip,ip,{255,255,255,0});
-    WiFi.softAP(WIFI_SSID, WIFI_PASSWORD,1,0,4);
-    ArduinoOTA.begin();
-    server.begin();
-    Serial.println("WiFi AP and TCP server started");
+    setupWiFi();
 
     // Initialize ESP-NOW
     if (esp_now_init() != ESP_OK)
@@ -966,41 +1010,37 @@ void setup()
     yawPID.reset(); // ✅ Reset yaw PID
     updatePIDControllers();
 
- xTaskCreatePinnedToCore(
-        FastTask,        // Task function
-        "FastTask",      // Name
-        4096,            // Stack size
-        NULL,            // Parameters
-        3,               // Priority
-        NULL,            // Task handle
-        1                // Core 1 (runs app code)
+    CREATE_TASK(
+        FastTask,
+        "FastTask",
+        FAST_TASK_STACK,
+        3,
+        NULL,
+        1
     );
 
-    xTaskCreatePinnedToCore(
+    CREATE_TASK(
         CommTask,
         "CommTask",
-        8192,
-        NULL,
+        COMM_TASK_STACK,
         2,
         NULL,
         1 // Core 0 — use Core 0 for Wi-Fi tasks to avoid conflicts
     );
 
-    xTaskCreatePinnedToCore(
+    CREATE_TASK(
         FailsafeTask,
         "FailsafeTask",
-        2048,
-        NULL,
+        FAILSAFE_TASK_STACK,
         1,
         NULL,
         1
     );
 
-    xTaskCreatePinnedToCore(
+    CREATE_TASK(
         OTATask,
         "OTATask",
-        2048,
-        NULL,
+        OTA_TASK_STACK,
         1,
         NULL,
         0


### PR DESCRIPTION
## Summary
- compute LEDC duty from frequency/resolution for accurate 1–2 ms pulses
- define PWM resolution and pins per board with ESP32-C3 support
- expose WiFi access point for direct telemetry

## Testing
- `pio run -e nodemcu-32s`
- `pio run -e esp32-c3-supermini`


------
https://chatgpt.com/codex/tasks/task_e_68aeeafdcef8832aa9fac91cc0ceb247