### PR TITLE
Invert ILITE throttle direction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -638,7 +638,8 @@ void onReceive(const uint8_t *mac, const uint8_t *incomingData, int len)
         rollSetpoint = command.rollAngle;
         yawSetpoint = command.yawAngle;
 
-        int throttleDelta = command.throttle - THROTTLE_HOVER;
+        // ILITE reports throttle inversely; invert to match stabilized command expectations
+        int throttleDelta = THROTTLE_HOVER - command.throttle;
         if (abs(throttleDelta) > THROTTLE_DEADBAND)
         {
             altitudeSetpoint += throttleDelta * 0.01f;


### PR DESCRIPTION
## Summary
- Invert ILITE throttle delta so that positive and negative inputs are reversed for stabilized command compatibility.

## Testing
- `pio run -e nodemcu-32s`

------
https://chatgpt.com/codex/tasks/task_e_68afb6a0e200832ab41992a8462bb84d