### PR TITLE
Broadcast identity for ILITE discovery

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,6 +192,8 @@ struct IdentityMessage {
     uint8_t mac[6];
 } __attribute__((packed));
 
+static const uint8_t kBroadcastMac[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
 // ==================== GLOBAL VARIABLES ====================
 // Hardware
 MPU6050 mpu;
@@ -337,6 +339,7 @@ uint8_t selfMac[6];
 bool ilitePaired = false;
 uint8_t commandPeer[6];
 bool commandPeerSet = false;
+unsigned long lastDiscoveryTime = 0;
 
 
 // ==================== IMPROVED COMMUNICATION FUNCTIONS ====================
@@ -1136,6 +1139,14 @@ void CommTask(void *pvParameters) {
     while (true) {
         handleIncomingData();
         streamTelemetry();
+        if (!ilitePaired && millis() - lastDiscoveryTime > 1000) {
+            IdentityMessage msg = {};
+            msg.type = DRONE_IDENTITY;
+            strncpy(msg.identity, DRONE_ID, sizeof(msg.identity));
+            memcpy(msg.mac, selfMac, 6);
+            esp_now_send(kBroadcastMac, (uint8_t *)&msg, sizeof(msg));
+            lastDiscoveryTime = millis();
+        }
         vTaskDelay(pdMS_TO_TICKS(5)); // ~20 Hz
     }
 }


### PR DESCRIPTION
## Summary
- Broadcast drone identity over ESP-NOW until paired so ILITE controllers can discover Dronegaze.
- Track last discovery broadcast time to avoid spamming.

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68b17a87bf94832aadc269391e4c4323