### PR TITLE
Restore failsafe without resetting ESP-NOW

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -613,12 +613,6 @@ void checkFailsafe()
             // Emergency stop
             targetOutputs.MFL = targetOutputs.MFR = targetOutputs.MBL = targetOutputs.MBR = MOTOR_MIN;
             isArmed = 0;
-            commandPeerSet = false;
-
-            if (ilitePaired)
-            {
-                ilitePaired = false;
-            }
 
             if (BUZZER_PIN >= 0 && millis() - lastAlarmTime > 5000)
             {


### PR DESCRIPTION
## Summary
- reintroduce failsafe timeout and CLI toggle
- stop motors on failsafe without dropping ESP-NOW pairing

## Testing
- `pio run -e nodemcu-32s`


------
https://chatgpt.com/codex/tasks/task_e_68b1973b74b0832a8731d4f17bc1ade9