### PR TITLE
Improve comms resilience and task priority

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -41,12 +41,13 @@ static void onDataRecv(const uint8_t* mac, const uint8_t* incomingData, int len)
 }
 
 void init(const char *ssid, const char *password, int tcpPort) {
+    // Run in AP+STA mode so ESP-NOW remains operational alongside SoftAP
     WiFi.mode(WIFI_AP_STA);
     WiFi.setTxPower(WIFI_POWER_8_5dBm);
+    WiFi.setSleep(false);
     WiFi.softAP(ssid, password);
-    WiFi.begin(ssid, password);
+
     esp_now_init();
-    esp_now_register_recv_cb(onDataRecv);
 
     esp_now_peer_info_t peerInfo{};
     memcpy(peerInfo.peer_addr, BroadcastMac, 6);


### PR DESCRIPTION
## Summary
- Avoid repeated pairing beeps by only acknowledging new ILITE connections
- Monitor connections and clean up stale peers to prevent memory growth
- Run communications task at higher priority
- Host telemetry via SoftAP while keeping ESP-NOW active with AP+STA mode

## Testing
- `pip install platformio`
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68b1b6bc0cd8832abd84ec2580814271