### PR TITLE
Simplify vertical control and gate yaw

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -19,7 +19,6 @@ struct TelemetryPacket {
   float pitchCorrection, rollCorrection, yawCorrection; // PID outputs
   uint16_t throttle;             // Current throttle command
   int8_t pitchAngle, rollAngle, yawAngle; // Commanded angles
-  float altitude;                // Estimated altitude
   float verticalAcc;             // Vertical acceleration in m/s^2
   uint32_t commandAge;           // Age of last command in ms
 } __attribute__((packed));

--- a/include/imu.h
+++ b/include/imu.h
@@ -8,7 +8,6 @@ void zero();
 float pitch();
 float roll();
 float yaw();
-float altitude();
 float verticalAcc();
 }
 

--- a/include/pid.h
+++ b/include/pid.h
@@ -18,21 +18,19 @@ struct PIDOutputs {
     float roll;
     float pitch;
     float yaw;
-    float altitude;
+    float vertical;
 };
 
 void updatePIDControllers(float pitchSetpoint,
                           float rollSetpoint,
                           float yawSetpoint,
-                          float altitudeSetpoint,
                           float pitch,
                           float roll,
                           float yaw,
-                          float altitude,
                           float verticalAcc,
+                          bool yawEnabled,
                           PIDController &pitchPID,
                           PIDController &rollPID,
                           PIDController &yawPID,
-                          PIDController &altitudePID,
                           PIDController &verticalAccelPID,
                           PIDOutputs &out);

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -14,7 +14,7 @@ static CascadedFilter rollQuad(1,200.0,20.0,0.707,FilterType::LOW_PASS);
 static CascadedFilter yawQuad(1,200.0,20.0,0.707,FilterType::LOW_PASS);
 
 static float g_pitch=0, g_roll=0, g_yaw=0;
-static float g_altitude=0, g_verticalAcc=0, g_verticalVel=0;
+static float g_verticalAcc=0;
 static float pitchOffset=0, rollOffset=0, yawOffset=0;
 static unsigned long lastUpdate=0;
 
@@ -60,8 +60,6 @@ void update() {
                    sin(pitchRad)*cos(rollRad)*ax_ms2+
                    cos(pitchRad)*sin(rollRad)*ay_ms2;
     g_verticalAcc = worldZ - 9.81f;
-    g_verticalVel += g_verticalAcc * dt;
-    g_altitude += g_verticalVel * dt;
 }
 
 void zero() {
@@ -69,13 +67,12 @@ void zero() {
     rollOffset = g_roll;
     pitchOffset = g_pitch;
     yawOffset = g_yaw;
-    g_altitude = 0; g_verticalVel = 0;
+
 }
 
 float pitch() { return g_pitch; }
 float roll() { return g_roll; }
 float yaw() { return g_yaw; }
-float altitude() { return g_altitude; }
 float verticalAcc() { return g_verticalAcc; }
 }
 

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -25,32 +25,29 @@ void PIDController::reset() {
 void updatePIDControllers(float pitchSetpoint,
                           float rollSetpoint,
                           float yawSetpoint,
-                          float altitudeSetpoint,
                           float pitch,
                           float roll,
                           float yaw,
-                          float altitude,
                           float verticalAcc,
+                          bool yawEnabled,
                           PIDController &pitchPID,
                           PIDController &rollPID,
                           PIDController &yawPID,
-                          PIDController &altitudePID,
                           PIDController &verticalAccelPID,
                           PIDOutputs &out) {
     float pitchError = pitchSetpoint - pitch;
     float rollError = rollSetpoint - roll;
-
-    float yawError = yawSetpoint - yaw;
-    if (yawError > 180) yawError -= 360;
-    else if (yawError < -180) yawError += 360;
-
     out.roll = rollPID.compute(rollError, 0.01f);
     out.pitch = pitchPID.compute(pitchError, 0.01f);
-    out.yaw = yawPID.compute(yawError, 0.01f);
-
-    float altitudeError = altitudeSetpoint - altitude;
-    float altitudePos = altitudePID.compute(altitudeError, 0.01f);
-    float accelCorr = verticalAccelPID.compute(-verticalAcc, 0.01f);
-    out.altitude = constrain(altitudePos + accelCorr, -150, 150);
+    if (yawEnabled) {
+        float yawError = yawSetpoint - yaw;
+        if (yawError > 180) yawError -= 360;
+        else if (yawError < -180) yawError += 360;
+        out.yaw = yawPID.compute(yawError, 0.01f);
+    } else {
+        yawPID.reset();
+        out.yaw = 0;
+    }
+    out.vertical = verticalAccelPID.compute(-verticalAcc, 0.01f);
 }
 


### PR DESCRIPTION
## Summary
- Drop altitude estimation and PID loop, rely on vertical acceleration damping only
- Add yaw control enable/disable commands and only apply yaw PID when enabled
- Update telemetry and IMU to remove altitude fields

## Testing
- `platformio run`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef820b98832a8d8190bc542d45d9