### PR TITLE
Isolate buzzer PWM on ESP32-C3

### DIFF
--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -17,6 +17,7 @@ static float pitchSlow = 0, rollSlow = 0, yawSlow = 0;
 static float g_pitch = 0, g_roll = 0, g_yaw = 0;
 static float g_verticalAcc = 0;
 static float pitchOffset = 0, rollOffset = 0, yawOffset = 0;
+static float verticalAccOffset = 0; // offset to remove initial bias
 static unsigned long lastUpdate = 0;
 
 void init() {
@@ -61,10 +62,13 @@ void update() {
     float az_ms2 = (float)az/ACC_SCALE*9.81f;
     float pitchRad = g_pitch*DEG_TO_RAD;
     float rollRad  = g_roll*DEG_TO_RAD;
-    float worldZ = cos(pitchRad)*cos(rollRad)*az_ms2 +
-                   sin(pitchRad)*cos(rollRad)*ax_ms2 +
-                   cos(pitchRad)*sin(rollRad)*ay_ms2;
-    g_verticalAcc = worldZ - 9.81f;
+    // Transform body acceleration into world-frame Z. Using the standard
+    // rotation (roll then pitch), world Z is
+    //   cos(roll)*cos(pitch)*az + sin(roll)*cos(pitch)*ay - sin(pitch)*ax
+    float worldZ = cos(rollRad)*cos(pitchRad)*az_ms2 +
+                   sin(rollRad)*cos(pitchRad)*ay_ms2 -
+                   sin(pitchRad)*ax_ms2;
+    g_verticalAcc = worldZ - 9.81f - verticalAccOffset; // remove gravity and offset
 }
 
 void zero() {
@@ -72,6 +76,7 @@ void zero() {
     rollOffset = g_roll;
     pitchOffset = g_pitch;
     yawOffset = g_yaw;
+    verticalAccOffset = g_verticalAcc;
 }
 
 float pitch() { return g_pitch; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,10 @@ const uint16_t OTA_TASK_STACK = 2048;
 #define CREATE_TASK(fn, name, stack, prio, handle, core) xTaskCreatePinnedToCore(fn, name, stack, NULL, prio, handle, core)
 #endif
 
-const int BUZZER_CHANNEL = 4;
+// Use LEDC channel 5 for the buzzer. Channels are paired by timer on the
+// ESP32‑C3 (0/1, 2/3, 4/5), so channel 5 uses timer2 which none of the motors
+// occupy. This prevents the buzzer from changing the motors' 50 Hz PWM.
+const int BUZZER_CHANNEL = 5;
 
 
 /// ==================== CONSTANTS ====================

--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -1,6 +1,10 @@
 #include "motor.h"
 
 namespace Motor {
+// On the ESP32‑C3, LEDC channels are paired by timer: channels 0/1 use timer0
+// and 2/3 use timer1. Channels 4/5 use timer2. By keeping the motors on
+// channels 0‑3 we occupy timers 0 and 1 only, leaving timer2 free for the
+// buzzer on channel 5 so their frequencies cannot conflict.
 static ESC escFL(0,0,50,16), escFR(0,1,50,16), escBL(0,2,50,16), escBR(0,3,50,16);
 static int pwmResolution = 16;
 
@@ -12,6 +16,8 @@ void Outputs::constrainAll() {
 }
 
 void init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes) {
+    // Assign channels sequentially; this maps the motors to timers 0 and 1.
+    // Timer2 remains unused and is dedicated to the buzzer (channel 5).
     escFL = ESC(pinFL,0,50,pwmRes);
     escFR = ESC(pinFR,1,50,pwmRes);
     escBL = ESC(pinBL,2,50,pwmRes);


### PR DESCRIPTION
## Summary
- Keep motors on LEDC channels 0-3 and dedicate channel 5/timer2 to the buzzer
- Correct IMU vertical acceleration transform to remove inverted offset
- Calibrate out initial vertical acceleration bias on startup

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68b335d686ec832aa3cf7a620f65dd2d