### PR TITLE
Fix PWM channel assignments and vertical accel sign

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@ const int PIN_MBR = 3;  // MBR
 const int BUZZER_PIN = 6;
 const uint32_t CPU_FREQ_MHZ = 160;
 
-const int PWM_RESOLUTION = 14;
+const int PWM_RESOLUTION = 16;
 
 // Reduced stack sizes for smaller RAM
 const uint16_t FAST_TASK_STACK = 2048*2;
@@ -537,8 +537,8 @@ void FastTask(void *pvParameters) {
         pitch = IMU::pitch();
        roll = IMU::roll();
        yaw = IMU::yaw();
-        // If the craft tilts beyond the safe angle, immediately disarm
-        if (fabs(pitch) > FLIP_ANGLE || fabs(roll) > FLIP_ANGLE) {
+        // If the craft tilts beyond the safe angle while armed, immediately disarm
+        if (isArmed && (fabs(pitch) > FLIP_ANGLE || fabs(roll) > FLIP_ANGLE)) {
             isArmed = false;
             beep(1000, 200);
             Motor::update(false, currentOutputs, targetOutputs);
@@ -602,7 +602,9 @@ void setup()
     Serial.begin(115200);
     Serial.println("Flight Controller Starting...");
     if (BUZZER_PIN >= 0) {
-        ledcSetup(BUZZER_CHANNEL, 1000, PWM_RESOLUTION);
+        // Use a standard 2 kHz buzzer tone with 8-bit resolution to avoid
+        // disturbing the motor PWM timers.
+        ledcSetup(BUZZER_CHANNEL, 2000, 8);
         ledcAttachPin(BUZZER_PIN, BUZZER_CHANNEL);
         beep(1000, 200);
         delay(200);

--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -22,10 +22,13 @@ void init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes) {
     // Assign channels sequentially; this maps the motors to timers 0 and 1.
     // Timer2 remains unused and is dedicated to the buzzer (channel 5).
 
+    // Keep channels sequential (0-3) so motors use only timers 0 and 1.
+    // This avoids sharing timer2 with the buzzer on channel 5 which can
+    // otherwise alter the motor PWM frequency.
     escFL = ESC(pinFL,0,50,pwmRes);
-    escFR = ESC(pinFR,2,50,pwmRes);
-    escBL = ESC(pinBL,3,50,pwmRes);
-    escBR = ESC(pinBR,4,50,pwmRes);
+    escFR = ESC(pinFR,1,50,pwmRes);
+    escBL = ESC(pinBL,2,50,pwmRes);
+    escBR = ESC(pinBR,3,50,pwmRes);
     pwmResolution = pwmRes;
     escFL.attach(); escFR.attach(); escBL.attach(); escBR.attach();
     // Verify all ESC channels operate at the expected 50 Hz. Any drift is logged


### PR DESCRIPTION
## Summary
- use sequential LEDC channels for motors to keep buzzer timer isolated
- flip IMU vertical acceleration sign
- standardize buzzer PWM setup and guard tilt failsafe to fire only when armed
- average IMU offsets over 3s of readings to prevent recalibration beeps

## Testing
- `pio run -e esp32-c3`


------
https://chatgpt.com/codex/tasks/task_e_68b4619d7980832a9d077e3bfd510b6f