### PR TITLE
Use timer interrupts for ESC on ESP32-C3

### DIFF
--- a/include/ESC.h
+++ b/include/ESC.h
@@ -1,30 +1,30 @@
 #pragma once
 #include <Arduino.h>
-#include <driver/mcpwm.h>
+#include <esp_timer.h>
 
 /*
- * ESC hardware PWM driver using MCPWM timers.
- * Replaces the previous LEDC implementation to guarantee a stable
- * 50 Hz PWM with 1–2 ms pulse width using dedicated motor-control
- * hardware timers. Sub‑1 ms pulses are allowed for safety routines
- * such as disarming before calibration.
+ * ESC driver using high‑resolution timer interrupts.
+ * Generates a 50 Hz PWM signal with 1–2 ms pulse width by
+ * toggling the output pin in esp_timer callbacks. Sub‑1 ms
+ * pulses are allowed for disarming and calibration routines.
  */
 
 class ESC {
 public:
-    ESC(int pin, mcpwm_unit_t unit, mcpwm_timer_t timer,
-        mcpwm_operator_t op, mcpwm_io_signals_t signal, uint32_t freq = 50);
+    explicit ESC(int pin, uint32_t freq = 50);
     bool attach();
     void arm(int pulse = 1000);
     void writeMicroseconds(int pulse); // constrained to 900–2000 µs
     uint32_t frequency() const;
 
 private:
+    static void onPeriod(void *arg);
+    static void onOff(void *arg);
+
     int _pin;
-    mcpwm_unit_t _unit;
-    mcpwm_timer_t _timer;
-    mcpwm_operator_t _op;
-    mcpwm_io_signals_t _signal;
     uint32_t _freq;
+    esp_timer_handle_t _periodic;
+    esp_timer_handle_t _offTimer;
+    volatile uint32_t _pulse;
 };
 

--- a/src/ESC.cpp
+++ b/src/ESC.cpp
@@ -1,32 +1,49 @@
 #include "ESC.h"
 
-ESC::ESC(int pin, mcpwm_unit_t unit, mcpwm_timer_t timer,
-         mcpwm_operator_t op, mcpwm_io_signals_t signal, uint32_t freq)
-    : _pin(pin), _unit(unit), _timer(timer), _op(op), _signal(signal), _freq(freq) {}
+ESC::ESC(int pin, uint32_t freq)
+    : _pin(pin), _freq(freq), _periodic(nullptr), _offTimer(nullptr), _pulse(1000) {}
 
 bool ESC::attach() {
-    mcpwm_gpio_init(_unit, _signal, _pin);
-    mcpwm_config_t cfg{};
-    cfg.frequency = _freq; // 50 Hz
-    cfg.cmpr_a = 0;
-    cfg.cmpr_b = 0;
-    cfg.counter_mode = MCPWM_UP_COUNTER;
-    cfg.duty_mode = MCPWM_DUTY_MODE_0;
-    mcpwm_init(_unit, _timer, &cfg);
-    return true;
+    pinMode(_pin, OUTPUT);
+
+    esp_timer_create_args_t periodArgs = {
+        .callback = &ESC::onPeriod,
+        .arg = this,
+        .dispatch_method = ESP_TIMER_TASK,
+        .name = "esc_period"};
+    if (esp_timer_create(&periodArgs, &_periodic) != ESP_OK) return false;
+
+    esp_timer_create_args_t offArgs = {
+        .callback = &ESC::onOff,
+        .arg = this,
+        .dispatch_method = ESP_TIMER_TASK,
+        .name = "esc_off"};
+    if (esp_timer_create(&offArgs, &_offTimer) != ESP_OK) return false;
+
+    return esp_timer_start_periodic(_periodic, 1000000 / _freq) == ESP_OK;
 }
 
-void ESC::arm(int pulse) {
-    writeMicroseconds(pulse);
-}
+void ESC::arm(int pulse) { writeMicroseconds(pulse); }
 
 static inline uint32_t clampu32(uint32_t v, uint32_t lo, uint32_t hi) {
     return v < lo ? lo : (v > hi ? hi : v);
 }
 
 void ESC::writeMicroseconds(int pulse) {
-    pulse = clampu32(pulse, 900, 2000); // allow sub-1ms for disarming
-    mcpwm_set_duty_in_us(_unit, _timer, _op, pulse);
+    _pulse = clampu32(pulse, 900, 2000); // allow sub-1ms for disarming
 }
 
 uint32_t ESC::frequency() const { return _freq; }
+
+void ESC::onPeriod(void *arg) {
+    auto *self = static_cast<ESC *>(arg);
+    digitalWrite(self->_pin, HIGH);
+    esp_timer_stop(self->_offTimer);
+    esp_timer_start_once(self->_offTimer, self->_pulse);
+}
+
+void ESC::onOff(void *arg) {
+    auto *self = static_cast<ESC *>(arg);
+    digitalWrite(self->_pin, LOW);
+}
+

--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -2,12 +2,11 @@
 
 namespace Motor {
 
-// Use dedicated MCPWM hardware timers for each motor output to ensure a
-// stable 50 Hz PWM signal with 1–2 ms pulse width.
-static ESC escFL(0, MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_A, MCPWM0A);
-static ESC escFR(0, MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_B, MCPWM0B);
-static ESC escBL(0, MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_OPR_A, MCPWM1A);
-static ESC escBR(0, MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_OPR_B, MCPWM1B);
+// Use timer-based PWM outputs for each motor at 50 Hz with 1–2 ms pulses.
+static ESC escFL(0);
+static ESC escFR(0);
+static ESC escBL(0);
+static ESC escBR(0);
 
 void calibrate()
 {
@@ -33,17 +32,10 @@ void Outputs::constrainAll() {
 }
 
 void init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes) {
-
-    // Assign channels sequentially; this maps the motors to timers 0 and 1.
-    // Timer2 remains unused and is dedicated to the buzzer (channel 5).
-
-    // Keep channels sequential (0-3) so motors use only timers 0 and 1.
-    // This avoids sharing timer2 with the buzzer on channel 5 which can
-    // otherwise alter the motor PWM frequency.
-    escFL = ESC(pinFL, MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_A, MCPWM0A);
-    escFR = ESC(pinFR, MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_OPR_B, MCPWM0B);
-    escBL = ESC(pinBL, MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_OPR_A, MCPWM1A);
-    escBR = ESC(pinBR, MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_OPR_B, MCPWM1B);
+    escFL = ESC(pinFL);
+    escFR = ESC(pinFR);
+    escBL = ESC(pinBL);
+    escBR = ESC(pinBR);
     escFL.attach(); escFR.attach(); escBL.attach(); escBR.attach();
 }
 


### PR DESCRIPTION
## Summary
- replace MCPWM-based ESC driver with esp_timer-based implementation
- update motor control to use timer-driven ESC outputs

## Testing
- `pio run -e esp32-c3`

------
https://chatgpt.com/codex/tasks/task_e_68b8a4b5b91c832a836246945d8fa90b