### PR TITLE
Use hardware PWM and harden initialization

### DIFF
--- a/include/ESC.h
+++ b/include/ESC.h
@@ -1,30 +1,21 @@
 #pragma once
 #include <Arduino.h>
-#include <esp_timer.h>
 
 /*
- * ESC driver using high‑resolution timer interrupts.
- * Generates a 50 Hz PWM signal with 1–2 ms pulse width by
- * toggling the output pin in esp_timer callbacks. Sub‑1 ms
- * pulses are allowed for disarming and calibration routines.
+ * ESC driver using hardware LEDC PWM for stable 50 Hz output.
+ * Each instance controls one LEDC channel and timer to generate
+ * 1–2 ms pulses required by standard RC ESCs. Sub-1 ms pulses
+ * are permitted for disarming and calibration.
  */
-
 class ESC {
 public:
-    explicit ESC(int pin, uint32_t freq = 50);
+    ESC(int pin, int channel, uint32_t freq = 50, uint8_t resolution = 16);
     bool attach();
-    void arm(int pulse = 1000);
     void writeMicroseconds(int pulse); // constrained to 900–2000 µs
-    uint32_t frequency() const;
-
 private:
-    static void onPeriod(void *arg);
-    static void onOff(void *arg);
-
     int _pin;
+    int _channel;
     uint32_t _freq;
-    esp_timer_handle_t _periodic;
-    esp_timer_handle_t _offTimer;
-    volatile uint32_t _pulse;
+    uint8_t _resolution;
+    uint32_t _period_us;
 };
-

--- a/include/motor.h
+++ b/include/motor.h
@@ -8,7 +8,7 @@ struct Outputs {
     void constrainAll();
 };
 
-void init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes);
+bool init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes);
 void mix(int base, int pitchCorr, int rollCorr, int yawCorr, Outputs &target);
 void update(bool isArmed, Outputs &current, const Outputs &target);
 void calibrate();

--- a/src/ESC.cpp
+++ b/src/ESC.cpp
@@ -1,49 +1,23 @@
 #include "ESC.h"
 
-ESC::ESC(int pin, uint32_t freq)
-    : _pin(pin), _freq(freq), _periodic(nullptr), _offTimer(nullptr), _pulse(1000) {}
-
-bool ESC::attach() {
-    pinMode(_pin, OUTPUT);
-
-    esp_timer_create_args_t periodArgs = {
-        .callback = &ESC::onPeriod,
-        .arg = this,
-        .dispatch_method = ESP_TIMER_TASK,
-        .name = "esc_period"};
-    if (esp_timer_create(&periodArgs, &_periodic) != ESP_OK) return false;
-
-    esp_timer_create_args_t offArgs = {
-        .callback = &ESC::onOff,
-        .arg = this,
-        .dispatch_method = ESP_TIMER_TASK,
-        .name = "esc_off"};
-    if (esp_timer_create(&offArgs, &_offTimer) != ESP_OK) return false;
-
-    return esp_timer_start_periodic(_periodic, 1000000 / _freq) == ESP_OK;
+ESC::ESC(int pin, int channel, uint32_t freq, uint8_t resolution)
+    : _pin(pin), _channel(channel), _freq(freq), _resolution(resolution) {
+    _period_us = 1000000UL / _freq;
 }
 
-void ESC::arm(int pulse) { writeMicroseconds(pulse); }
-
-static inline uint32_t clampu32(uint32_t v, uint32_t lo, uint32_t hi) {
-    return v < lo ? lo : (v > hi ? hi : v);
+bool ESC::attach() {
+    // Configure the LEDC channel and attach the pin. Return false on failure.
+    if (ledcSetup(_channel, _freq, _resolution) == 0) {
+        return false;
+    }
+    ledcAttachPin(_pin, _channel);
+    writeMicroseconds(900); // ensure disarmed on start
+    return true;
 }
 
 void ESC::writeMicroseconds(int pulse) {
-    _pulse = clampu32(pulse, 1, 2001); // allow sub-1ms for disarming
+    pulse = constrain(pulse, 900, 2000);
+    uint32_t duty_max = (1UL << _resolution) - 1;
+    uint32_t duty = (static_cast<uint32_t>(pulse) * duty_max) / _period_us;
+    ledcWrite(_channel, duty);
 }
-
-uint32_t ESC::frequency() const { return _freq; }
-
-void ESC::onPeriod(void *arg) {
-    auto *self = static_cast<ESC *>(arg);
-    digitalWrite(self->_pin, HIGH);
-    esp_timer_stop(self->_offTimer);
-    esp_timer_start_once(self->_offTimer, self->_pulse);
-}
-
-void ESC::onOff(void *arg) {
-    auto *self = static_cast<ESC *>(arg);
-    digitalWrite(self->_pin, LOW);
-}
-

--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -2,25 +2,30 @@
 
 namespace Motor {
 
-// Use timer-based PWM outputs for each motor at 50 Hz with 1–2 ms pulses.
-static ESC escFL(0);
-static ESC escFR(0);
-static ESC escBL(0);
-static ESC escBR(0);
+// Use hardware LEDC channels for stable 50 Hz PWM pulses.
+static ESC escFL(0, 0);
+static ESC escFR(0, 1);
+static ESC escBL(0, 2);
+static ESC escBR(0, 3);
 
 void calibrate()
 {
-    // hold motors disarmed (<1 ms) for 3 s to ensure props are removed
-    escFL.writeMicroseconds(0); escFR.writeMicroseconds(0);
-    escBL.writeMicroseconds(0); escBR.writeMicroseconds(0);
+    // Hold motors in a disarmed state to ensure props are removed
+    escFL.writeMicroseconds(900); escFR.writeMicroseconds(900);
+    escBL.writeMicroseconds(900); escBR.writeMicroseconds(900);
     delay(3000);
 
-    // standard ESC calibration: max then min throttle
+    // Standard ESC calibration: max then min throttle
     escFL.writeMicroseconds(2000); escFR.writeMicroseconds(2000);
     escBL.writeMicroseconds(2000); escBR.writeMicroseconds(2000);
     delay(1000);
     escFL.writeMicroseconds(1000); escFR.writeMicroseconds(1000);
     escBL.writeMicroseconds(1000); escBR.writeMicroseconds(1000);
+    delay(1000);
+
+    // Return to a safe disarmed level
+    escFL.writeMicroseconds(900); escFR.writeMicroseconds(900);
+    escBL.writeMicroseconds(900); escBR.writeMicroseconds(900);
     delay(1000);
 }
 
@@ -31,12 +36,16 @@ void Outputs::constrainAll() {
     MBR = constrain(MBR, 1000, 2000);
 }
 
-void init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes) {
-    escFL = ESC(pinFL);
-    escFR = ESC(pinFR);
-    escBL = ESC(pinBL);
-    escBR = ESC(pinBR);
-    escFL.attach(); escFR.attach(); escBL.attach(); escBR.attach();
+bool init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes) {
+    escFL = ESC(pinFL, 0, 50, pwmRes);
+    escFR = ESC(pinFR, 1, 50, pwmRes);
+    escBL = ESC(pinBL, 2, 50, pwmRes);
+    escBR = ESC(pinBR, 3, 50, pwmRes);
+    bool ok = escFL.attach();
+    ok = escFR.attach() && ok;
+    ok = escBL.attach() && ok;
+    ok = escBR.attach() && ok;
+    return ok;
 }
 
 int ease(int current, int target) {
@@ -64,10 +73,10 @@ void update(bool isArmed, Outputs &current, const Outputs &target) {
         escBL.writeMicroseconds(current.MBL);
         escBR.writeMicroseconds(current.MBR);
     } else {
-        escFL.writeMicroseconds(1000);
-        escFR.writeMicroseconds(1000);
-        escBL.writeMicroseconds(1000);
-        escBR.writeMicroseconds(1000);
+        escFL.writeMicroseconds(900);
+        escFR.writeMicroseconds(900);
+        escBL.writeMicroseconds(900);
+        escBR.writeMicroseconds(900);
     }
 }
 }


### PR DESCRIPTION
## Summary
- Replace timer-based ESC driver with LEDC hardware PWM for stable 50 Hz motor control
- Calibrate motors with safe disarm pulses and enforce shutdown when not armed
- Run control loop at 1 kHz with high priority and sequentially validate motor init to prevent unsafe startup

## Testing
- `python -m platformio run -e esp32-c3`


------
https://chatgpt.com/codex/tasks/task_e_68c68b5922b8832a89cc6d20fa6ab5aa