### PR TITLE
Use ESP32 MCPWM and drop C3 support

### DIFF
--- a/include/ESC.h
+++ b/include/ESC.h
@@ -1,21 +1,24 @@
 #pragma once
 #include <Arduino.h>
+#include <driver/mcpwm.h>
 
 /*
- * ESC driver using hardware LEDC PWM for stable 50 Hz output.
- * Each instance controls one LEDC channel and timer to generate
- * 1–2 ms pulses required by standard RC ESCs. Sub-1 ms pulses
- * are permitted for disarming and calibration.
+ * ESC driver using the ESP32 MCPWM hardware timers for stable 50 Hz output.
+ * Each instance controls one MCPWM generator to produce 1–2 ms pulses
+ * required by standard RC ESCs. Sub-1 ms pulses are permitted for
+ * disarming and calibration.
  */
 class ESC {
 public:
-    ESC(int pin, int channel, uint32_t freq = 50, uint8_t resolution = 16);
+    ESC(mcpwm_unit_t unit, mcpwm_timer_t timer, mcpwm_generator_t gen,
+        int pin, uint32_t freq = 50);
     bool attach();
     void writeMicroseconds(int pulse); // constrained to 900–2000 µs
+
 private:
+    mcpwm_unit_t _unit;
+    mcpwm_timer_t _timer;
+    mcpwm_generator_t _gen;
     int _pin;
-    int _channel;
     uint32_t _freq;
-    uint8_t _resolution;
-    uint32_t _period_us;
 };

--- a/include/motor.h
+++ b/include/motor.h
@@ -8,7 +8,7 @@ struct Outputs {
     void constrainAll();
 };
 
-bool init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes);
+bool init(int pinFL, int pinFR, int pinBL, int pinBR);
 void mix(int base, int pitchCorr, int rollCorr, int yawCorr, Outputs &target);
 void update(bool isArmed, Outputs &current, const Outputs &target);
 void calibrate();

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,30 +7,6 @@ upload_speed = 921600
 lib_deps = electroniccats/MPU6050@^1.4.4
             ArduinoOTA
 
-[env:esp32-c3-OTA]
-platform = espressif32
-board = esp32-c3-devkitm-1
-upload_port = 192.168.4.1
-framework = arduino
-monitor_speed = 115200
-upload_speed = 921600
-lib_deps = electroniccats/MPU6050@^1.4.4
-            ArduinoOTA
-
-
-[env:esp32-c3]
-platform = espressif32
-board = esp32-c3-devkitm-1
-framework = arduino
-monitor_speed = 115200
-upload_speed = 921600
-build_flags = 
-  -D ARDUINO_USB_MODE=1
-  -D ARDUINO_USB_CDC_ON_BOOT=1
-lib_deps = electroniccats/MPU6050@^1.4.4
-            ArduinoOTA            
-
-
 [env:dronegazeOTA]
 platform = espressif32
 upload_port = 192.168.4.1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,40 +15,13 @@
 #include "motor.h"
 
 // ==================== BOARD CONFIGURATION ====================
-// Select pin mappings and task sizes based on target board
-
-#define CONFIG_IDF_TARGET_ESP32C3
-
-
-
-#if defined(CONFIG_IDF_TARGET_ESP32C3)
-// ESP32-C3 Super Mini (RISC-V single core)
-const int PIN_MFL = 1; // MTL
-const int PIN_MFR = 2; // MTR
-const int PIN_MBL = 0; // MBL
-const int PIN_MBR = 3;  // MBR
-const int BUZZER_PIN = 6;
-const uint32_t CPU_FREQ_MHZ = 160;
-
-const int PWM_RESOLUTION = 16;
-
-// Reduced stack sizes for smaller RAM
-const uint16_t FAST_TASK_STACK = 2048*2;
-const uint16_t COMM_TASK_STACK = 4096*2;
-const uint16_t FAILSAFE_TASK_STACK = 2048*2;
-const uint16_t TELEMETRY_TASK_STACK = 2048*2;
-const uint16_t OTA_TASK_STACK = 2048*2;
-const uint16_t BUZZER_TASK_STACK = 1024*2;
-#define CREATE_TASK(fn, name, stack, prio, handle, core) xTaskCreate(fn, name, stack, NULL, prio, handle)
-#else
-// Default ESP32 (e.g., NodeMCU-32S)
+// Default ESP32 (e.g., NodeMCU-32S) pin mappings and task sizes
 const int PIN_MFL = 14;
 const int PIN_MFR = 27;
 const int PIN_MBL = 26;
 const int PIN_MBR = 25;
 const int BUZZER_PIN = -1; // No buzzer by default
 const uint32_t CPU_FREQ_MHZ = 240;
-const int PWM_RESOLUTION = 16;
 const uint16_t FAST_TASK_STACK = 4096;
 const uint16_t COMM_TASK_STACK = 8192;
 const uint16_t FAILSAFE_TASK_STACK = 2048;
@@ -56,12 +29,10 @@ const uint16_t TELEMETRY_TASK_STACK = 4096;
 const uint16_t OTA_TASK_STACK = 2048;
 const uint16_t BUZZER_TASK_STACK = 1024;
 #define CREATE_TASK(fn, name, stack, prio, handle, core) xTaskCreatePinnedToCore(fn, name, stack, NULL, prio, handle, core)
-#endif
 
 
-// Use LEDC channel 5 for the buzzer. Channels are paired by timer on the
-// ESP32‑C3 (0/1, 2/3, 4/5), so channel 5 uses timer2 which none of the motors
-// occupy. This prevents the buzzer from changing the motors' 50 Hz PWM.
+// Use LEDC channel 5 for an optional buzzer. This channel operates
+// independently of the MCPWM timers driving the motors.
 
 const int BUZZER_CHANNEL = 5;
 
@@ -539,7 +510,7 @@ void setup()
 
     setCpuFrequencyMhz(CPU_FREQ_MHZ);
     // Initialize motor outputs
-    if (!Motor::init(PIN_MFL, PIN_MFR, PIN_MBL, PIN_MBR, PWM_RESOLUTION)) {
+    if (!Motor::init(PIN_MFL, PIN_MFR, PIN_MBL, PIN_MBR)) {
         Serial.println("Motor init failed");
         while (true) {
             beep(2000, 500);

--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -2,11 +2,11 @@
 
 namespace Motor {
 
-// Use hardware LEDC channels for stable 50 Hz PWM pulses.
-static ESC escFL(0, 0);
-static ESC escFR(0, 1);
-static ESC escBL(0, 2);
-static ESC escBR(0, 3);
+// Use ESP32 MCPWM hardware timers for stable 50 Hz PWM pulses.
+static ESC escFL(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_GEN_A, 0);
+static ESC escFR(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_GEN_B, 0);
+static ESC escBL(MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_GEN_A, 0);
+static ESC escBR(MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_GEN_B, 0);
 
 void calibrate()
 {
@@ -36,11 +36,11 @@ void Outputs::constrainAll() {
     MBR = constrain(MBR, 1000, 2000);
 }
 
-bool init(int pinFL, int pinFR, int pinBL, int pinBR, int pwmRes) {
-    escFL = ESC(pinFL, 0, 50, pwmRes);
-    escFR = ESC(pinFR, 1, 50, pwmRes);
-    escBL = ESC(pinBL, 2, 50, pwmRes);
-    escBR = ESC(pinBR, 3, 50, pwmRes);
+bool init(int pinFL, int pinFR, int pinBL, int pinBR) {
+    escFL = ESC(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_GEN_A, pinFL);
+    escFR = ESC(MCPWM_UNIT_0, MCPWM_TIMER_0, MCPWM_GEN_B, pinFR);
+    escBL = ESC(MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_GEN_A, pinBL);
+    escBR = ESC(MCPWM_UNIT_0, MCPWM_TIMER_1, MCPWM_GEN_B, pinBR);
     bool ok = escFL.attach();
     ok = escFR.attach() && ok;
     ok = escBL.attach() && ok;


### PR DESCRIPTION
## Summary
- drop ESP32-C3 build configurations and board conditionals
- drive ESCs using ESP32 MCPWM hardware timers
- simplify motor init and board constants for the dual-core ESP32

## Testing
- `pio run -e nodemcu-32s`

------
https://chatgpt.com/codex/tasks/task_e_68c690e3bcb0832a8da6e79a1bdb4345