### PR TITLE
Add throttle-aware altitude damping

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -18,5 +18,6 @@ void computeCorrections(float pitchSetpoint,
                         float gyroY,
                         float gyroZ,
                         float verticalAcc,
+                        bool throttleStable,
                         bool yawEnabled,
                         ControlOutputs &out);

--- a/src/control.cpp
+++ b/src/control.cpp
@@ -10,6 +10,7 @@ void computeCorrections(float pitchSetpoint,
                         float gyroY,
                         float gyroZ,
                         float verticalAcc,
+                        bool throttleStable,
                         bool yawEnabled,
                         ControlOutputs &out) {
     // Simple PD stabilizer inspired by open-source DIY controllers like
@@ -17,7 +18,7 @@ void computeCorrections(float pitchSetpoint,
     // proportional term while gyro rates provide damping.
     const float ANGLE_KP = 4.0f;   // proportional gain on angle error
     const float RATE_KD  = 0.1f;   // damping from gyro rate
-    const float VERT_KP  = 0.02f;  // vertical acceleration damping
+    const float VERT_KP  = 20.0f;  // throttle units per m/s^2 of vertical acceleration
 
     float rollError  = rollSetpoint  - roll;
     float pitchError = pitchSetpoint - pitch;
@@ -29,5 +30,5 @@ void computeCorrections(float pitchSetpoint,
     out.roll  = ANGLE_KP * rollError  - RATE_KD * gyroX;
     out.pitch = ANGLE_KP * pitchError - RATE_KD * gyroY;
     out.yaw   = yawEnabled ? ANGLE_KP * yawError - RATE_KD * gyroZ : 0.0f;
-    out.vertical = -VERT_KP * verticalAcc;
+    out.vertical = throttleStable ? -VERT_KP * verticalAcc : 0.0f;
 }


### PR DESCRIPTION
## Summary
- Increase throttle stability threshold to 30 units
- Apply altitude damping only when throttle is steady and above idle
- Boost vertical acceleration gain for stronger climb/fall resistance

## Testing
- `platformio run -e nodemcu-32s`


------
https://chatgpt.com/codex/tasks/task_e_68c7c7d51938832ab2dc251d83be442d