### PR TITLE
Fix inverted vertical stabilization

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -30,5 +30,5 @@ void computeCorrections(float pitchSetpoint,
     out.roll  = ANGLE_KP * rollError  - RATE_KD * gyroX;
     out.pitch = ANGLE_KP * pitchError - RATE_KD * gyroY;
     out.yaw   = yawEnabled ? ANGLE_KP * yawError - RATE_KD * gyroZ : 0.0f;
-    out.vertical = throttleStable ? -VERT_KP * verticalAcc : 0.0f;
+    out.vertical = throttleStable ? VERT_KP * verticalAcc : 0.0f;
 }

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -48,6 +48,6 @@ void updatePIDControllers(float pitchSetpoint,
         yawPID.reset();
         out.yaw = 0;
     }
-    out.vertical = verticalAccelPID.compute(-verticalAcc, 0.01f);
+    out.vertical = verticalAccelPID.compute(verticalAcc, 0.01f);
 }
 


### PR DESCRIPTION
## Summary
- Ensure throttle correction reacts against vertical acceleration to stabilize climb and descent

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68c7d0cea054832aa51c386ca2be0bfb