### PR TITLE
Improve communications reliability and task scheduling

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -36,7 +36,8 @@ struct IdentityMessage {
     uint8_t mac[6];
 } __attribute__((packed));
 
-void init(const char *ssid, const char *password, int tcpPort);
+bool init(const char *ssid, const char *password, int tcpPort);
+bool init(const char *ssid, const char *password, int tcpPort, esp_now_recv_cb_t recvCallback);
 bool receiveCommand(ThrustCommand &cmd);
 bool paired();
 extern const uint8_t BroadcastMac[6];


### PR DESCRIPTION
## Summary
- update the communications initialization helper to return success, reuse the broadcast peer, and optionally register the user-provided ESP-NOW receive callback
- guard shared command/link state with critical sections, replace the heap-backed message buffer, and generate telemetry/failsafe output from thread-safe snapshots
- stabilize communication-related FreeRTOS tasks with deterministic delays, core pinning, and improved handshake/peer tracking

## Testing
- `platformio run` *(fails: platformio executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6ce95548832ab29ad10a239b17d1