### PR TITLE
Add stabilization toggle command

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -14,6 +14,7 @@ extern bool serialActive;
 extern bool isArmed;
 extern Motor::Outputs currentOutputs;
 extern Motor::Outputs targetOutputs;
+extern bool stabilizationEnabled;
 
 namespace Commands {
 
@@ -80,6 +81,12 @@ void handleCommand(const String &cmd) {
         isArmed = false;
         Motor::update(isArmed, currentOutputs, targetOutputs);
         sendLine("ACK: Motors disarmed");
+    } else if (trimmed.equalsIgnoreCase("stabilization on")) {
+        stabilizationEnabled = true;
+        sendLine("ACK: Stabilization enabled");
+    } else if (trimmed.equalsIgnoreCase("stabilization off")) {
+        stabilizationEnabled = false;
+        sendLine("ACK: Stabilization disabled");
     } else {
         sendLine("ERROR: Unknown command");
     }


### PR DESCRIPTION
## Summary
- add a `stabilizationEnabled` runtime flag and commands to toggle it from the console
- skip PID-based attitude and vertical corrections when stabilization is disabled so motors follow raw throttle

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cae80b1be0832aa70d3e3aac755a39