### PR TITLE
Add controller-adjustable attitude biases

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -5,6 +5,7 @@
 extern WiFiClient client;
 extern float pitch, roll, yaw;
 extern float yawSetpoint;
+extern float pitchBias, rollBias, yawBias;
 extern bool yawControlEnabled;
 extern bool enableFilters;
 extern bool enableQuadFilters;
@@ -46,6 +47,7 @@ void handleCommand(const String &cmd) {
         sendLine("System: " + String(millis()) + "ms uptime");
         sendLine("Pitch:" + String(pitch, 2) + " Roll:" + String(roll, 2) + " Yaw:" + String(yaw, 2));
         sendLine("Yaw Setpoint: " + String(yawSetpoint, 2) + "\xC2\xB0");
+        sendLine("Bias Pitch:" + String(pitchBias, 2) + " Roll:" + String(rollBias, 2) + " Yaw:" + String(yawBias, 2));
     } else if(trimmed == "failsafe on"){failsafe_enable=1; sendLine("Enabled failsafe mode");}
     else if(trimmed == "failsafe off"){failsafe_enable=0; sendLine("Disabled failsafe mode");}
     else if(trimmed == "filters on"){enableFilters = true; sendLine("Enabled filters");}
@@ -59,6 +61,15 @@ void handleCommand(const String &cmd) {
     } else if (trimmed == "yawoff") {
         yawControlEnabled = false;
         sendLine("ACK: Yaw control disabled");
+    } else if (trimmed.startsWith("pitchbias ")) {
+        pitchBias = trimmed.substring(10).toFloat();
+        sendLine("ACK: Pitch bias set to " + String(pitchBias, 2) + "\xC2\xB0");
+    } else if (trimmed.startsWith("rollbias ")) {
+        rollBias = trimmed.substring(9).toFloat();
+        sendLine("ACK: Roll bias set to " + String(rollBias, 2) + "\xC2\xB0");
+    } else if (trimmed.startsWith("yawbias ")) {
+        yawBias = trimmed.substring(8).toFloat();
+        sendLine("ACK: Yaw bias set to " + String(yawBias, 2) + "\xC2\xB0");
     } else if (trimmed.startsWith("yaw ")) {
         float newYawSetpoint = trimmed.substring(4).toFloat();
         yawSetpoint = newYawSetpoint;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,6 +90,7 @@ Motor::Outputs targetOutputs{MOTOR_MIN, MOTOR_MIN, MOTOR_MIN, MOTOR_MIN};
 float pitch = 0, roll = 0, yaw = 0;
 float pitchCorrection = 0, rollCorrection = 0, yawCorrection = 0;
 float verticalCorrection = 0;
+float pitchBias = 0.0f, rollBias = 0.0f, yawBias = 0.0f;
 float pitchSetpoint = 0, rollSetpoint = 0, yawSetpoint = 0; // angle targets
 bool yawControlEnabled = false;
 bool stabilizationEnabled = true;
@@ -563,9 +564,9 @@ void FastTask(void *pvParameters) {
         yaw = IMU::yaw();
 
         Comms::ThrustCommand currentCommand = loadCommandSnapshot();
-        pitchSetpoint = currentCommand.pitchAngle;
-        rollSetpoint = currentCommand.rollAngle;
-        yawSetpoint = currentCommand.yawAngle;
+        pitchSetpoint = currentCommand.pitchAngle + pitchBias;
+        rollSetpoint = currentCommand.rollAngle + rollBias;
+        yawSetpoint = currentCommand.yawAngle + yawBias;
 
         // Shut down the motors if a steep tilt persists without being commanded.
         bool bias = fabs(pitchSetpoint) > COMMAND_BIAS_LIMIT ||


### PR DESCRIPTION
## Summary
- add bias variables for pitch, roll, and yaw and apply them to control setpoints
- expose CLI commands to configure the new biases and report them through the status command

## Testing
- ⚠️ `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caf3581810832abdeba22041aeab72