### PR TITLE
Restore configurable PID control with telemetry commands

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -8,6 +8,23 @@ struct ControlOutputs {
     float vertical;
 };
 
+namespace Control {
+
+enum class Axis : uint8_t {
+    Roll = 0,
+    Pitch = 1,
+    Yaw = 2,
+    Vertical = 3,
+};
+
+struct Gains {
+    float kp;
+    float ki;
+    float kd;
+};
+
+void init();
+
 void computeCorrections(float pitchSetpoint,
                         float rollSetpoint,
                         float yawSetpoint,
@@ -21,3 +38,24 @@ void computeCorrections(float pitchSetpoint,
                         bool throttleStable,
                         bool yawEnabled,
                         ControlOutputs &out);
+
+bool pidEnabled();
+void setPidEnabled(bool enabled);
+
+bool filtersEnabled();
+void setFiltersEnabled(bool enabled);
+
+bool quadFiltersEnabled();
+void setQuadFiltersEnabled(bool enabled);
+
+Gains getGains(Axis axis);
+void setGains(Axis axis, const Gains &gains);
+void resetGains();
+
+float filterAlpha();
+void setFilterAlpha(float alpha);
+
+float quadFilterAlpha();
+void setQuadFilterAlpha(float alpha);
+
+} // namespace Control

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1,14 +1,15 @@
 #include "commands.h"
 #include <WiFi.h>
+#include <cstdlib>
+#include <cstdio>
 #include "motor.h"
+#include "control.h"
 
 extern WiFiClient client;
 extern float pitch, roll, yaw;
 extern float yawSetpoint;
 extern float pitchBias, rollBias, yawBias;
 extern bool yawControlEnabled;
-extern bool enableFilters;
-extern bool enableQuadFilters;
 extern bool failsafe_enable;
 extern bool telemetryEnabled;
 extern bool serialActive;
@@ -17,6 +18,36 @@ extern Motor::Outputs currentOutputs;
 extern Motor::Outputs targetOutputs;
 extern bool stabilizationEnabled;
 extern bool requestIMUZero();
+
+static bool parseAxisToken(const String &token, Control::Axis &axis) {
+    if (token.equalsIgnoreCase("roll")) {
+        axis = Control::Axis::Roll;
+        return true;
+    }
+    if (token.equalsIgnoreCase("pitch")) {
+        axis = Control::Axis::Pitch;
+        return true;
+    }
+    if (token.equalsIgnoreCase("yaw")) {
+        axis = Control::Axis::Yaw;
+        return true;
+    }
+    if (token.equalsIgnoreCase("vertical") || token.equalsIgnoreCase("vert")) {
+        axis = Control::Axis::Vertical;
+        return true;
+    }
+    return false;
+}
+
+static const char *axisName(Control::Axis axis) {
+    switch (axis) {
+        case Control::Axis::Roll: return "roll";
+        case Control::Axis::Pitch: return "pitch";
+        case Control::Axis::Yaw: return "yaw";
+        case Control::Axis::Vertical: return "vertical";
+    }
+    return "unknown";
+}
 
 namespace Commands {
 
@@ -49,12 +80,110 @@ void handleCommand(const String &cmd) {
         sendLine("Pitch:" + String(pitch, 2) + " Roll:" + String(roll, 2) + " Yaw:" + String(yaw, 2));
         sendLine("Yaw Setpoint: " + String(yawSetpoint, 2) + "\xC2\xB0");
         sendLine("Bias Pitch:" + String(pitchBias, 2) + " Roll:" + String(rollBias, 2) + " Yaw:" + String(yawBias, 2));
+        sendLine(String("PID Control: ") + (Control::pidEnabled() ? "ON" : "OFF"));
+        sendLine(String("Filters: primary ") + (Control::filtersEnabled() ? "ON" : "OFF") +
+                 " (alpha=" + String(Control::filterAlpha(), 3) + "), secondary " +
+                 (Control::quadFiltersEnabled() ? "ON" : "OFF") +
+                 " (alpha=" + String(Control::quadFilterAlpha(), 3) + ")");
     } else if(trimmed == "failsafe on"){failsafe_enable=1; sendLine("Enabled failsafe mode");}
     else if(trimmed == "failsafe off"){failsafe_enable=0; sendLine("Disabled failsafe mode");}
-    else if(trimmed == "filters on"){enableFilters = true; sendLine("Enabled filters");}
-    else if(trimmed == "filters off"){enableFilters = false; sendLine("Disabled filters");}
-    else if(trimmed == "quadfilters on"){enableQuadFilters = true; sendLine("Enabled quad filters");}
-    else if(trimmed == "quadfilters off"){enableQuadFilters = false; sendLine("Disabled quad filters");}
+    else if (trimmed == "filters on") {
+        Control::setFiltersEnabled(true);
+        sendLine("ACK: Filters enabled");
+    }
+    else if (trimmed == "filters off") {
+        Control::setFiltersEnabled(false);
+        sendLine("ACK: Filters disabled");
+    }
+    else if (trimmed.startsWith("filters alpha ")) {
+        String valueStr = trimmed.substring(14);
+        valueStr.trim();
+        char *endPtr = nullptr;
+        float alpha = strtof(valueStr.c_str(), &endPtr);
+        if (endPtr == valueStr.c_str()) {
+            sendLine("ERROR: Invalid filter alpha");
+        } else if (alpha < 0.0f || alpha > 1.0f) {
+            sendLine("ERROR: Filter alpha must be between 0 and 1");
+        } else {
+            Control::setFilterAlpha(alpha);
+            sendLine("ACK: Primary filter alpha set to " + String(Control::filterAlpha(), 3));
+        }
+    }
+    else if (trimmed == "filters status") {
+        sendLine(String("Primary filter: ") + (Control::filtersEnabled() ? "ON" : "OFF") +
+                 " alpha=" + String(Control::filterAlpha(), 3));
+        sendLine(String("Secondary filter: ") + (Control::quadFiltersEnabled() ? "ON" : "OFF") +
+                 " alpha=" + String(Control::quadFilterAlpha(), 3));
+    }
+    else if (trimmed == "quadfilters on") {
+        Control::setQuadFiltersEnabled(true);
+        sendLine("ACK: Quad filters enabled");
+    }
+    else if (trimmed == "quadfilters off") {
+        Control::setQuadFiltersEnabled(false);
+        sendLine("ACK: Quad filters disabled");
+    }
+    else if (trimmed.startsWith("quadfilters alpha ")) {
+        String valueStr = trimmed.substring(18);
+        valueStr.trim();
+        char *endPtr = nullptr;
+        float alpha = strtof(valueStr.c_str(), &endPtr);
+        if (endPtr == valueStr.c_str()) {
+            sendLine("ERROR: Invalid quad filter alpha");
+        } else if (alpha < 0.0f || alpha > 1.0f) {
+            sendLine("ERROR: Quad filter alpha must be between 0 and 1");
+        } else {
+            Control::setQuadFilterAlpha(alpha);
+            sendLine("ACK: Secondary filter alpha set to " + String(Control::quadFilterAlpha(), 3));
+        }
+    }
+    else if (trimmed == "pid on") {
+        Control::setPidEnabled(true);
+        sendLine("ACK: PID control enabled");
+    }
+    else if (trimmed == "pid off") {
+        Control::setPidEnabled(false);
+        sendLine("ACK: PID control disabled");
+    }
+    else if (trimmed == "pid reset") {
+        Control::resetGains();
+        sendLine("ACK: PID gains reset to defaults");
+    }
+    else if (trimmed == "pid show") {
+        Control::Gains rollG = Control::getGains(Control::Axis::Roll);
+        Control::Gains pitchG = Control::getGains(Control::Axis::Pitch);
+        Control::Gains yawG = Control::getGains(Control::Axis::Yaw);
+        Control::Gains vertG = Control::getGains(Control::Axis::Vertical);
+        sendLine("PID roll: Kp=" + String(rollG.kp, 3) + " Ki=" + String(rollG.ki, 3) + " Kd=" + String(rollG.kd, 3));
+        sendLine("PID pitch: Kp=" + String(pitchG.kp, 3) + " Ki=" + String(pitchG.ki, 3) + " Kd=" + String(pitchG.kd, 3));
+        sendLine("PID yaw: Kp=" + String(yawG.kp, 3) + " Ki=" + String(yawG.ki, 3) + " Kd=" + String(yawG.kd, 3));
+        sendLine("PID vertical: Kp=" + String(vertG.kp, 3) + " Ki=" + String(vertG.ki, 3) + " Kd=" + String(vertG.kd, 3));
+    }
+    else if (trimmed.startsWith("pid set ")) {
+        String rest = trimmed.substring(8);
+        rest.trim();
+        int spaceIdx = rest.indexOf(' ');
+        if (spaceIdx < 0) {
+            sendLine("ERROR: Usage pid set <axis> <Kp> <Ki> <Kd>");
+        } else {
+            String axisToken = rest.substring(0, spaceIdx);
+            Control::Axis axis;
+            if (!parseAxisToken(axisToken, axis)) {
+                sendLine("ERROR: Unknown axis; use roll, pitch, yaw, or vertical");
+            } else {
+                String values = rest.substring(spaceIdx + 1);
+                values.trim();
+                float kp = 0.0f, ki = 0.0f, kd = 0.0f;
+                if (sscanf(values.c_str(), "%f %f %f", &kp, &ki, &kd) != 3) {
+                    sendLine("ERROR: Usage pid set <axis> <Kp> <Ki> <Kd>");
+                } else {
+                    Control::Gains gains{kp, ki, kd};
+                    Control::setGains(axis, gains);
+                    sendLine(String("ACK: PID ") + axisName(axis) + " gains updated");
+                }
+            }
+        }
+    }
     else if (trimmed == "yawon") {
         yawControlEnabled = true;
         yawSetpoint = yaw;

--- a/src/control.cpp
+++ b/src/control.cpp
@@ -1,4 +1,247 @@
 #include "control.h"
+#include "pid.h"
+#include <EEPROM.h>
+#include <array>
+#include <math.h>
+
+namespace {
+
+constexpr uint32_t CONFIG_MAGIC = 0x434E544C; // "CNTL"
+constexpr size_t AXIS_COUNT = 4;
+constexpr float DEFAULT_FILTER_ALPHA = 0.25f;
+constexpr float DEFAULT_QUAD_ALPHA = 0.1f;
+constexpr size_t STORAGE_SIZE = 128;
+
+struct RuntimeConfig {
+    Control::Gains roll;
+    Control::Gains pitch;
+    Control::Gains yaw;
+    Control::Gains vertical;
+    float filterAlpha;
+    float quadFilterAlpha;
+    bool pidEnabled;
+    bool filtersEnabled;
+    bool quadFiltersEnabled;
+};
+
+struct ConfigBlob {
+    uint32_t magic;
+    Control::Gains roll;
+    Control::Gains pitch;
+    Control::Gains yaw;
+    Control::Gains vertical;
+    float filterAlpha;
+    float quadFilterAlpha;
+    uint8_t flags;
+    uint8_t reserved[7];
+};
+
+struct LowPassFilter {
+    float state;
+    bool initialized;
+
+    LowPassFilter() : state(0.0f), initialized(false) {}
+
+    float process(float value, float alpha) {
+        alpha = constrain(alpha, 0.0f, 1.0f);
+        if (!initialized) {
+            state = value;
+            initialized = true;
+        } else {
+            state += alpha * (value - state);
+        }
+        return state;
+    }
+
+    void reset() {
+        state = 0.0f;
+        initialized = false;
+    }
+};
+
+const Control::Gains kDefaultGains[AXIS_COUNT] = {
+    {4.0f, 0.0f, 0.1f},   // Roll
+    {4.0f, 0.0f, 0.1f},   // Pitch
+    {4.0f, 0.0f, 0.1f},   // Yaw
+    {20.0f, 0.0f, 5.0f},  // Vertical acceleration
+};
+
+RuntimeConfig g_config{
+    kDefaultGains[0],
+    kDefaultGains[1],
+    kDefaultGains[2],
+    kDefaultGains[3],
+    DEFAULT_FILTER_ALPHA,
+    DEFAULT_QUAD_ALPHA,
+    false,
+    false,
+    false,
+};
+
+PIDController g_rollPID;
+PIDController g_pitchPID;
+PIDController g_yawPID;
+PIDController g_verticalPID;
+
+std::array<LowPassFilter, AXIS_COUNT> g_stage1Filters{};
+std::array<LowPassFilter, AXIS_COUNT> g_stage2Filters{};
+
+bool g_storageReady = false;
+bool g_initialized = false;
+uint32_t g_lastMicros = 0;
+
+size_t axisIndex(Control::Axis axis) {
+    return static_cast<size_t>(axis);
+}
+
+const Control::Gains &defaultGains(Control::Axis axis) {
+    return kDefaultGains[axisIndex(axis)];
+}
+
+float sanitizeAlpha(float value, float fallback) {
+    if (isnan(value) || isinf(value) || value < 0.0f || value > 1.0f) {
+        return fallback;
+    }
+    return value;
+}
+
+void applyGainsToControllers() {
+    g_rollPID.Kp = g_config.roll.kp;
+    g_rollPID.Ki = g_config.roll.ki;
+    g_rollPID.Kd = g_config.roll.kd;
+
+    g_pitchPID.Kp = g_config.pitch.kp;
+    g_pitchPID.Ki = g_config.pitch.ki;
+    g_pitchPID.Kd = g_config.pitch.kd;
+
+    g_yawPID.Kp = g_config.yaw.kp;
+    g_yawPID.Ki = g_config.yaw.ki;
+    g_yawPID.Kd = g_config.yaw.kd;
+
+    g_verticalPID.Kp = g_config.vertical.kp;
+    g_verticalPID.Ki = g_config.vertical.ki;
+    g_verticalPID.Kd = g_config.vertical.kd;
+}
+
+void resetControllers() {
+    g_rollPID.reset();
+    g_pitchPID.reset();
+    g_yawPID.reset();
+    g_verticalPID.reset();
+    g_lastMicros = micros();
+}
+
+void resetFilters() {
+    for (auto &filter : g_stage1Filters) {
+        filter.reset();
+    }
+    for (auto &filter : g_stage2Filters) {
+        filter.reset();
+    }
+}
+
+void resetAxisFilters(Control::Axis axis) {
+    const size_t idx = axisIndex(axis);
+    g_stage1Filters[idx].reset();
+    g_stage2Filters[idx].reset();
+}
+
+ConfigBlob toBlob() {
+    ConfigBlob blob{};
+    blob.magic = CONFIG_MAGIC;
+    blob.roll = g_config.roll;
+    blob.pitch = g_config.pitch;
+    blob.yaw = g_config.yaw;
+    blob.vertical = g_config.vertical;
+    blob.filterAlpha = g_config.filterAlpha;
+    blob.quadFilterAlpha = g_config.quadFilterAlpha;
+    blob.flags = 0;
+    if (g_config.pidEnabled) blob.flags |= 0x01;
+    if (g_config.filtersEnabled) blob.flags |= 0x02;
+    if (g_config.quadFiltersEnabled) blob.flags |= 0x04;
+    return blob;
+}
+
+void fromBlob(const ConfigBlob &blob) {
+    g_config.roll = blob.roll;
+    g_config.pitch = blob.pitch;
+    g_config.yaw = blob.yaw;
+    g_config.vertical = blob.vertical;
+    g_config.filterAlpha = sanitizeAlpha(blob.filterAlpha, DEFAULT_FILTER_ALPHA);
+    g_config.quadFilterAlpha = sanitizeAlpha(blob.quadFilterAlpha, DEFAULT_QUAD_ALPHA);
+    g_config.pidEnabled = (blob.flags & 0x01) != 0;
+    g_config.filtersEnabled = (blob.flags & 0x02) != 0;
+    g_config.quadFiltersEnabled = (blob.flags & 0x04) != 0;
+}
+
+void persistConfig() {
+    if (!g_storageReady) {
+        return;
+    }
+    ConfigBlob blob = toBlob();
+    EEPROM.put(0, blob);
+    EEPROM.commit();
+}
+
+float computeDt() {
+    const uint32_t now = micros();
+    float dt = 0.0f;
+    if (g_lastMicros != 0) {
+        const uint32_t delta = now - g_lastMicros;
+        dt = static_cast<float>(delta) / 1e6f;
+    }
+    g_lastMicros = now;
+    if (dt <= 0.0f || dt > 0.05f) {
+        dt = 0.01f;
+    }
+    return dt;
+}
+
+float applyFilters(Control::Axis axis, float value) {
+    const size_t idx = axisIndex(axis);
+    if (g_config.filtersEnabled) {
+        value = g_stage1Filters[idx].process(value, sanitizeAlpha(g_config.filterAlpha, DEFAULT_FILTER_ALPHA));
+    } else {
+        g_stage1Filters[idx].reset();
+    }
+
+    if (g_config.quadFiltersEnabled) {
+        value = g_stage2Filters[idx].process(value, sanitizeAlpha(g_config.quadFilterAlpha, DEFAULT_QUAD_ALPHA));
+    } else {
+        g_stage2Filters[idx].reset();
+    }
+
+    return value;
+}
+
+} // namespace
+
+namespace Control {
+
+void init() {
+    if (g_initialized) {
+        return;
+    }
+    g_initialized = true;
+
+    if (EEPROM.begin(STORAGE_SIZE)) {
+        g_storageReady = true;
+        ConfigBlob blob{};
+        EEPROM.get(0, blob);
+        if (blob.magic == CONFIG_MAGIC) {
+            fromBlob(blob);
+        } else {
+            persistConfig();
+        }
+    } else {
+        g_storageReady = false;
+        Serial.println("WARN: Control configuration storage unavailable");
+    }
+
+    applyGainsToControllers();
+    resetControllers();
+    resetFilters();
+}
 
 void computeCorrections(float pitchSetpoint,
                         float rollSetpoint,
@@ -13,22 +256,161 @@ void computeCorrections(float pitchSetpoint,
                         bool throttleStable,
                         bool yawEnabled,
                         ControlOutputs &out) {
-    // Simple PD stabilizer inspired by open-source DIY controllers like
-    // MultiWii and the Crazyflie firmware.  Angles are corrected with a
-    // proportional term while gyro rates provide damping.
-    const float ANGLE_KP = 4.0f;   // proportional gain on angle error
-    const float RATE_KD  = 0.1f;   // damping from gyro rate
-    const float VERT_KP  = 20.0f;  // throttle units per m/s^2 of vertical acceleration
+    out.roll = out.pitch = out.yaw = out.vertical = 0.0f;
 
-    float rollError  = rollSetpoint  - roll;
-    float pitchError = pitchSetpoint - pitch;
-    float yawError   = yawSetpoint   - yaw;
+    const float rollError = rollSetpoint - roll;
+    const float pitchError = pitchSetpoint - pitch;
+    float yawError = yawSetpoint - yaw;
+    if (yawError > 180.0f) yawError -= 360.0f;
+    else if (yawError < -180.0f) yawError += 360.0f;
 
-    if (yawError > 180) yawError -= 360;
-    else if (yawError < -180) yawError += 360;
+    const float filteredRollError = applyFilters(Axis::Roll, rollError);
+    const float filteredPitchError = applyFilters(Axis::Pitch, pitchError);
 
-    out.roll  = ANGLE_KP * rollError  - RATE_KD * gyroX;
-    out.pitch = ANGLE_KP * pitchError - RATE_KD * gyroY;
-    out.yaw   = yawEnabled ? ANGLE_KP * yawError - RATE_KD * gyroZ : 0.0f;
-    out.vertical = throttleStable ? VERT_KP * verticalAcc : 0.0f;
+    float filteredYawError = 0.0f;
+    if (yawEnabled) {
+        filteredYawError = applyFilters(Axis::Yaw, yawError);
+    } else {
+        resetAxisFilters(Axis::Yaw);
+    }
+
+    float filteredVerticalError = 0.0f;
+    if (throttleStable) {
+        const float verticalError = -verticalAcc;
+        filteredVerticalError = applyFilters(Axis::Vertical, verticalError);
+    } else {
+        resetAxisFilters(Axis::Vertical);
+    }
+
+    if (g_config.pidEnabled) {
+        const float dt = computeDt();
+        out.roll = g_rollPID.compute(filteredRollError, dt);
+        out.pitch = g_pitchPID.compute(filteredPitchError, dt);
+        if (yawEnabled) {
+            out.yaw = g_yawPID.compute(filteredYawError, dt);
+        } else {
+            g_yawPID.reset();
+            out.yaw = 0.0f;
+        }
+
+        if (throttleStable) {
+            out.vertical = g_verticalPID.compute(filteredVerticalError, dt);
+        } else {
+            g_verticalPID.reset();
+            out.vertical = 0.0f;
+        }
+    } else {
+        out.roll = g_config.roll.kp * filteredRollError - g_config.roll.kd * gyroX;
+        out.pitch = g_config.pitch.kp * filteredPitchError - g_config.pitch.kd * gyroY;
+        if (yawEnabled) {
+            out.yaw = g_config.yaw.kp * filteredYawError - g_config.yaw.kd * gyroZ;
+        } else {
+            out.yaw = 0.0f;
+        }
+        if (throttleStable) {
+            out.vertical = g_config.vertical.kp * filteredVerticalError;
+        } else {
+            out.vertical = 0.0f;
+        }
+    }
 }
+
+bool pidEnabled() {
+    return g_config.pidEnabled;
+}
+
+void setPidEnabled(bool enabled) {
+    if (g_config.pidEnabled == enabled) {
+        return;
+    }
+    g_config.pidEnabled = enabled;
+    resetControllers();
+    persistConfig();
+}
+
+bool filtersEnabled() {
+    return g_config.filtersEnabled;
+}
+
+void setFiltersEnabled(bool enabled) {
+    if (g_config.filtersEnabled == enabled) {
+        return;
+    }
+    g_config.filtersEnabled = enabled;
+    resetFilters();
+    persistConfig();
+}
+
+bool quadFiltersEnabled() {
+    return g_config.quadFiltersEnabled;
+}
+
+void setQuadFiltersEnabled(bool enabled) {
+    if (g_config.quadFiltersEnabled == enabled) {
+        return;
+    }
+    g_config.quadFiltersEnabled = enabled;
+    resetFilters();
+    persistConfig();
+}
+
+Gains getGains(Axis axis) {
+    switch (axis) {
+        case Axis::Roll: return g_config.roll;
+        case Axis::Pitch: return g_config.pitch;
+        case Axis::Yaw: return g_config.yaw;
+        case Axis::Vertical: return g_config.vertical;
+    }
+    return g_config.roll;
+}
+
+void setGains(Axis axis, const Gains &gains) {
+    switch (axis) {
+        case Axis::Roll: g_config.roll = gains; break;
+        case Axis::Pitch: g_config.pitch = gains; break;
+        case Axis::Yaw: g_config.yaw = gains; break;
+        case Axis::Vertical: g_config.vertical = gains; break;
+    }
+    applyGainsToControllers();
+    persistConfig();
+}
+
+void resetGains() {
+    g_config.roll = defaultGains(Axis::Roll);
+    g_config.pitch = defaultGains(Axis::Pitch);
+    g_config.yaw = defaultGains(Axis::Yaw);
+    g_config.vertical = defaultGains(Axis::Vertical);
+    applyGainsToControllers();
+    resetControllers();
+    persistConfig();
+}
+
+float filterAlpha() {
+    return g_config.filterAlpha;
+}
+
+void setFilterAlpha(float alpha) {
+    alpha = sanitizeAlpha(alpha, DEFAULT_FILTER_ALPHA);
+    if (fabsf(g_config.filterAlpha - alpha) < 1e-6f) {
+        return;
+    }
+    g_config.filterAlpha = alpha;
+    resetFilters();
+    persistConfig();
+}
+
+float quadFilterAlpha() {
+    return g_config.quadFilterAlpha;
+}
+
+void setQuadFilterAlpha(float alpha) {
+    alpha = sanitizeAlpha(alpha, DEFAULT_QUAD_ALPHA);
+    if (fabsf(g_config.quadFilterAlpha - alpha) < 1e-6f) {
+        return;
+    }
+    g_config.quadFilterAlpha = alpha;
+    resetFilters();
+    persistConfig();
+}
+
+} // namespace Control


### PR DESCRIPTION
## Summary
- reinstate the PID-based stabilization pipeline with optional single- and dual-stage filtering and persist its configuration in EEPROM
- expose telemetry commands to enable PID control, toggle filters, tune filter alphas, and adjust or reset axis-specific PID gains while reporting their status
- wire the flight tasks to the restored control module and initialize persisted settings during setup

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6e529128832a91f5455b29edfec1